### PR TITLE
Update fetch front end to use base64 blob api

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,6 @@ And give them their own layouts inside. */
       <h1>CYF Workshops</h1>
     </header>
     <readme-component></readme-component>
-    <scrip>
       <script>
       class ReadmeComponent extends HTMLElement {
         constructor() {

--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>CYF Workshops</title>
     <meta name="description" content="Workshops for CYF classes" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js" defer async></script>
     <style>
       /* Here's our design 
 It's fonts, colours, and spacing.
@@ -121,28 +121,28 @@ And give them their own layouts inside. */
       <h1>CYF Workshops</h1>
     </header>
     <readme-component></readme-component>
-    <script>
+    <scrip>
+      <script>
       class ReadmeComponent extends HTMLElement {
         constructor() {
           super();
           this.attachShadow({ mode: "open" });
         }
-
         connectedCallback() {
           this.fetchReadme();
         }
-
         async fetchReadme() {
           try {
             const response = await fetch(
-              "https://raw.githubusercontent.com/CodeYourFuture/CYF-Workshops/main/readme.md"
+              "https://api.github.com/repos/CodeYourFuture/CYF-Workshops/readme"
             );
             if (!response.ok) {
               console.error("Failed to fetch README: " + response.status);
               return;
             }
-            const md = await response.text();
-            this.render(md);
+            const json = await response.json();
+            const decodedContent = atob(json.content);
+            this.render(decodedContent);
           } catch (error) {
             console.error(error);
           }


### PR DESCRIPTION
I realised I was using github raw but really we want to be able to go to a recognisable API. This is the same one the curriculum website uses and this is a simplified example we can use in fetch recaps.