### PR TITLE
Fix link for VS Code debugger tutorial

### DIFF
--- a/debugging/readme.md
+++ b/debugging/readme.md
@@ -3,7 +3,7 @@
 ## Prep
 
 - [ ] Re-read this article about [Mental Models](https://jamesclear.com/mental-models)
-- [ ] Watch this video about [VSCode Debugger](https://developer.chrome.com/docs/devtools/javascript/) and follow along with the mini-workshop
+- [ ] Watch this video about [VSCode Debugger](https://code.visualstudio.com/docs/introvideos/debugging) and follow along with the mini-workshop
 - [ ] Open this [CYF Workshops repo](https://github.com/CodeYourFuture/CYF-Workshops/) in VSCode and go to the `debugging/bank` folder to find the problem bank.
 
 Whew, that's loads! But we did set it all as coursework, so you have done it already, right? 😉


### PR DESCRIPTION
Does what it says on the tin. As discussed here https://github.com/CodeYourFuture/CYF-Workshops/pull/164/files#r1412725424