### PR TITLE
Change avgDaysInYear to avgDaysInMonth

### DIFF
--- a/js1-wk1-eval/level-500.js
+++ b/js1-wk1-eval/level-500.js
@@ -1,7 +1,7 @@
 
 
-const avgDaysInYear = Math.floor(365 / 12);
+const avgDaysInMonth = Math.floor(365 / 12);
 
 // Without running any code,
-// Predict and explain what the value of avgDaysInYear will evaluate to
+// Predict and explain what the value of avgDaysInMonth will evaluate to
 // You can use documentation to look up what Math.floor does


### PR DESCRIPTION
# Context

While working through the exercises for tomorrow's day plan I found this variable. I was confused about what it did given the name was `avgDaysInYear` but the functionally it gives us the average days in a month. 

# QA Steps

1. Just sense checking that this is in fact a better variable name and will cause less confusion

Many thanks 🙏 